### PR TITLE
Fixes PR editing with the editor specified

### DIFF
--- a/src/commands/gitCommands.js
+++ b/src/commands/gitCommands.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const crypto = require("crypto");
-const {exec} = require("child_process");
+const {exec, spawnSync} = require("child_process");
 const {errorMessages} = require("../utils/messages");
 
 const axios = require("axios");
@@ -60,8 +60,11 @@ const editDescriptionAndCreatePullRequest = ({owner, repo, branchName}) => {
         jiraUrlBase: readFromConfig("jiraUrlBase"),
     });
     fs.writeFileSync(descriptionFileName, preparedTemplate);
-    const childProcess = exec(`${editor} ${descriptionFileName}`);
-    childProcess.on("close", () => createPullRequest({owner, repo, branchName, descriptionFileName}));
+
+    spawnSync(`${editor}`, [`${descriptionFileName}`], {
+        stdio: 'inherit'
+    });
+    createPullRequest({owner, repo, branchName, descriptionFileName});
 };
 
 const createPullRequest = ({owner, repo, branchName, descriptionFileName}) => {


### PR DESCRIPTION
Instead of `exec`ing async, we can do a spawnSync and set it to inherit the standard input. Idea from https://stackoverflow.com/a/17110285/238845.